### PR TITLE
Update main.go to fix complile error

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 		CheckErr(err)
 		*passPtr = strings.TrimSpace(string(bytePassword))
 	}
-	client, err := proxmox.NewClient(fmt.Sprintf("https://%s/api2/json", *hostPtr), nil, &tls.Config{InsecureSkipVerify: true}, "", 300)
+	client, err := proxmox.NewClient(fmt.Sprintf("https://%s/api2/json", *hostPtr), nil, "", &tls.Config{InsecureSkipVerify: true}, "", 300)
 	CheckErr(err)
 	CheckErr(client.Login(*userPtr, *passPtr, ""))
 	vmr := proxmox.NewVmRef(*vmidPtr)


### PR DESCRIPTION
fix compile error
.\main.go:84:130: not enough arguments in call to proxmox.NewClient 
have (string, nil, *tls.Config, string, number)
want (string, *http.Client, string, *tls.Config, string, int)